### PR TITLE
Fix: 유저 판단 기록 기본 키 변경

### DIFF
--- a/src/main/java/Farm/Team4/findOwn/domain/member/MemberDesignHistory.java
+++ b/src/main/java/Farm/Team4/findOwn/domain/member/MemberDesignHistory.java
@@ -10,9 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberDesignHistory {
     @Id
+    @OneToOne
+    private Design design;
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
-    @OneToOne
-    private Design design;
+
 }

--- a/src/main/java/Farm/Team4/findOwn/domain/member/MemberTrademarkHistory.java
+++ b/src/main/java/Farm/Team4/findOwn/domain/member/MemberTrademarkHistory.java
@@ -10,9 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberTrademarkHistory {
     @Id
+    @OneToOne
+    private Trademark trademark;
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
-    @OneToOne
-    private Trademark trademark;
+
 }


### PR DESCRIPTION
- 유저 판단 기록을 member_id로 기본 키로 두면 중복이 됨
- 따라서 해당 출원번호를 기준으로 기본 키 설정