### PR TITLE
Fix: restTemplate 자체 객체 변환 사용, XmlMapper 사용 X

### DIFF
--- a/src/main/java/Farm/Team4/findOwn/service/design/DesignService.java
+++ b/src/main/java/Farm/Team4/findOwn/service/design/DesignService.java
@@ -56,18 +56,13 @@ public class DesignService {
         HttpEntity<Void> request = new HttpEntity<>(headers);
         log.info("Request Message 생성완료");
 
-        String xmlContent = restTemplate.exchange(
+        Response response = restTemplate.exchange(
                 searchDesignUrl + "?serviceKey=" + dataServiceKey + "&articleName=" + URLEncoder.encode(articleName, StandardCharsets.UTF_8),
                 HttpMethod.GET,
                 request,
-                String.class
+                Response.class
         ).getBody();
         log.info("공공데이터포털 api 정보 수신 완료");
-
-        ObjectMapper xmlMapper = new XmlMapper();
-        Response response = xmlMapper.readValue(xmlContent, Response.class);
-        log.info("xml parsing 완료");
-        
         return response.getBody().getItems();
     }
     public List<Design> selectRegisteredTrademark(List<Item> apiResult){

--- a/src/main/java/Farm/Team4/findOwn/service/trademark/TrademarkService.java
+++ b/src/main/java/Farm/Team4/findOwn/service/trademark/TrademarkService.java
@@ -34,21 +34,17 @@ public class TrademarkService {
     public List<Item> findTrademark(String searchString) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<Void> request = new HttpEntity(headers);
+
         restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8)); // Xml response UTF-8 encoding
-        String xmlContent = restTemplate.exchange(
+
+        Response response = restTemplate.exchange(
                 searchTrademarkUrl + "?serviceKey=" + dataServiceKey + "&searchString=" + searchString,
                 HttpMethod.GET,
                 request,
-                String.class
+                Response.class
         ).getBody();
         log.info("공공데이터포털 api 데이터 수신 완료");
-
-        ObjectMapper xmlMapper = new XmlMapper();
-        Response response = xmlMapper.readValue(xmlContent, Response.class);
-        log.info("xml parsing 완료");
-
-        List<Item> items = response.getBody().getItems();
-        return items;
+        return response.getBody().getItems();
     }
     public List<Trademark> selectRegisteredTrademark(List<Item> apiResult){
         List<Trademark> trademarks = apiResult.stream()


### PR DESCRIPTION
- RestTemplate 자체 객체변환이 가능해서 혹시 되려나 싶어서 했는데 진짜 됨.
- 코드가 짧아지고 필요한 dependency도 작아질 예정